### PR TITLE
Include minecraft dependency definition in mods.toml

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,3 +18,9 @@ Spooky forest stuff for spooky jam'''
     versionRange="[34.1.0,)"
     ordering="NONE"
     side="BOTH"
+  [[dependencies.whisperwoods]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.16.3,)"
+    ordering="NONE"
+    side="BOTH"


### PR DESCRIPTION
Subject/Reason (Bug fix, new feature, etc.):

I noticed that your mods.toml is missing the dependency definition for Minecraft correlating to Whisperwoods Forge version.

mods.toml need to specify their sideness so Minecraft/Forge knows whether the mod needs to be available on the client, the server, or both. If a mod uses the modId for dependencies.<value_of_modId>, it also helps with ServerPackCreator identifying clientside-only mods. [Reference issue #70](https://github.com/Griefed/ServerPackCreator/issues/70) of ServerPackCreator.

Let me know what you think. 👋

Cheers,
Griefed

<sub>Legal Disclaimer:
ANY PULL REQUEST SUBMITTED TO "The Project" (github.com/itsmeow/whisperwoods) AND MERGED INTO A RELEASED VERSION OF THE MODIFICATION (content released via CurseForge.com) BECOMES PROPERTY OF "THE OWNER" (its_meow and partner cybercat5555). ALL RIGHTS TO THE SUBMITTED CONTENT IS TRANSFERRED TO THE OWNER. Credit may or may not be given at The Owner's choice.</sub>