### PR TITLE
actually check the light level for the Zotzpyres

### DIFF
--- a/common/src/main/java/dev/itsmeow/whisperwoods/entity/EntityZotzpyre.java
+++ b/common/src/main/java/dev/itsmeow/whisperwoods/entity/EntityZotzpyre.java
@@ -112,7 +112,7 @@ public class EntityZotzpyre extends EntityMonsterWithTypes implements FlyingAnim
         if (pos.getY() >= world.getSeaLevel() && !BiomeTypes.getTypes(ResourceKey.create(Registry.BIOME_REGISTRY, ((ServerLevel)world).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY).getKey(world.getBiome(pos)))).contains(BiomeTypes.JUNGLE)) {
             return false;
         } else {
-            return checkAnyLightMonsterSpawnRules(type, world, reason, pos, rand);
+            return world.getLightEmission(pos) <= 3 && checkAnyLightMonsterSpawnRules(type, world, reason, pos, rand);
         }
     }
 


### PR DESCRIPTION
## Features/Fixes

- Added a spawn condition for the Zotzpyres so they don't spawn everywhere in every light condition

- Currently the maximum light level is 3 but that can be changed